### PR TITLE
Fix duplicate event and append when creating shapes

### DIFF
--- a/pbr.js
+++ b/pbr.js
@@ -898,11 +898,6 @@ function drawRandomShape() {
     el.setAttribute("stroke", "#333");
     el.setAttribute("stroke-width", "1");
     svg.appendChild(el);
-
-    sceneObjects.push({ el: el, textureIndex: currentTextureIndex });
-    el.addEventListener('click', () => selectTexture(currentTextureIndex));
-
-    svg.appendChild(el);
     sceneObjects.push({ el: el, textureIndex: currentTextureIndex });
     el.addEventListener('click', (e) => {
         e.stopPropagation();


### PR DESCRIPTION
## Summary
- remove duplicate DOM manipulation in `drawRandomShape`

## Testing
- `node --check pbr.js`

------
https://chatgpt.com/codex/tasks/task_e_6856b3c5ca5883299aea814680d95b39