### PR TITLE
Fix create texture title attribute newline

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,7 @@
             </div>
 
             <div class="action-row">
-                <button id="btn-create-texture"
-                        title="Simulating creation of a new texture from resource manager">
+                <button id="btn-create-texture" title="Simulating creation of a new texture from resource manager">
                     Create new texture
                 </button>
             </div>


### PR DESCRIPTION
## Summary
- keep the `btn-create-texture` button's `title` attribute on one line

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6856b604a8e4832996144da4213b7853