### PR TITLE
Fix favorites drag preview alignment, label trimming, sync and nesting layout

### DIFF
--- a/pbr.js
+++ b/pbr.js
@@ -41,6 +41,7 @@ let favoriteNodeById = new Map();
 let favoriteSourceRows = [];
 let favoriteCollapsed = false;
 let favoriteDrag = null;
+let refreshFavoritesView = null;
 
 
 function setEditorEnabled(enabled) {
@@ -257,6 +258,8 @@ function loadTextureIntoEditor(idx) {
     toggleEmissionRows();
     toggleThinFilmRows();
     toggleGeometryRows();
+
+    if (refreshFavoritesView) refreshFavoritesView();
 
     // 6) re-gray all disabled inputs & sync popovers
     document.querySelectorAll('#palette .content .row input')
@@ -1347,6 +1350,9 @@ function buildFavoritesFeature() {
         clone.classList.add('favorite-row');
         clone.dataset.favoriteKey = key;
 
+        const cloneLabel = clone.querySelector('label');
+        if (cloneLabel) cloneLabel.textContent = cloneLabel.textContent.replace(/^\s+/, '');
+
         clone.querySelectorAll('input, button, .drag-handle').forEach(el => {
             if (!el.classList.contains('favorite-star') && !el.classList.contains('favorite-arrow')) {
                 el.removeAttribute('id');
@@ -1442,7 +1448,6 @@ function buildFavoritesFeature() {
         if (node.children.length && !node.collapsed) {
             const childWrap = document.createElement('div');
             childWrap.className = 'favorite-children';
-            childWrap.style.paddingLeft = '22px';
             node.children.forEach(childId => renderNode(childId, childWrap));
             into.appendChild(childWrap);
         }
@@ -1453,6 +1458,8 @@ function buildFavoritesFeature() {
         favoriteRows.forEach(nodeId => renderNode(nodeId, list));
         syncSourceFavoriteStars();
     }
+
+    refreshFavoritesView = renderFavorites;
 
     function isDescendant(candidateParentId, nodeId) {
         if (candidateParentId === nodeId) return true;
@@ -1482,14 +1489,14 @@ function buildFavoritesFeature() {
 
     function updatePreview(targetRow, mode) {
         if (!targetRow || !preview) return;
-        const listRect = list.getBoundingClientRect();
+        const sectionRect = section.getBoundingClientRect();
         const rect = targetRow.getBoundingClientRect();
-        let top = rect.top - listRect.top;
-        let left = rect.left - listRect.left;
+        let top = rect.top - sectionRect.top;
+        let left = rect.left - sectionRect.left;
         let width = rect.width;
-        if (mode === 'after') top = rect.bottom - listRect.top;
+        if (mode === 'after') top = rect.bottom - sectionRect.top;
         if (mode === 'child') {
-            top = rect.bottom - listRect.top;
+            top = rect.bottom - sectionRect.top;
             left += 26;
             width -= 26;
         }
@@ -2362,5 +2369,4 @@ function showRenderPopover() {
         window.addEventListener('click', onClick, true);
     }, 0);
 }
-
 


### PR DESCRIPTION
### Motivation
- Fix multiple bugs in the Favorites UI: the drag insert preview line was positioned one row too high, cloned favorite rows preserved leading whitespace in labels, favorite controls did not refresh when the editor loaded new texture/object values, and nested favorite rows were indented so far that controls could be pushed off-screen.

### Description
- Calculate the favorites drag/drop preview position relative to the favorites `section` (use `section.getBoundingClientRect()` instead of the list rect) so the insertion indicator aligns correctly inside the list.
- Trim leading whitespace from the cloned row label in `cloneInteractiveRow` so favorited labels like `"   Color:"` become `"Color:"`.
- Add a `refreshFavoritesView` hook (set to `renderFavorites`) and invoke it from `loadTextureIntoEditor` so favorite rows are refreshed when the editor loads a new texture/object.
- Remove the explicit `paddingLeft` on the nested `favorite-children` wrapper so nested controls line up with top-level favorites and no longer shift off-screen.

### Testing
- Ran `node --check pbr.js` to validate JavaScript syntax, which succeeded.
- Executed a Playwright smoke script that navigated to `index.html`, favorited rows and captured a screenshot to validate preview alignment, label trimming and nested layout, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dcfb50b4083299c6670092ee470ff)